### PR TITLE
Add initial support for Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ argument option "-v" or "--version" will display the current version of the appl
 
 argument option "-h" or "--help" will display the list of command options
 
-argument option "-i" or "--i" will allow user input the single file or files by passing the directory
+argument option "-i" or "--i" will allow user input the single file or files by passing the directory. It supports both .txt and .md (feature: Heading)
+
 
 ----
 ## Prerequisites

--- a/src/com/company/MDUtils.java
+++ b/src/com/company/MDUtils.java
@@ -1,0 +1,83 @@
+package com.company;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class MDUtils {
+    public static void createHTMLFromMd(File file) throws IOException {
+        String convertedText = MDUtils.readFile(file);
+
+        String title = convertedText.split("<br/>")[0].replace("# ","");
+
+        String body = MDUtils.getBodyFromText(convertedText.split("<br/>"));
+
+
+        // Complete HTML file
+        String html = "<!doctype html>\r\n"
+                + "<html lang=\"en\">\r\n"
+                + "<head>\r\n"
+                + "  <meta charset=\"utf-8\">\r\n"
+                + "  <title>"
+                + title
+                + "</title>\r\n"
+                + "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\r\n"
+                + "</head>\r\n"
+                + "<body>\r\n"
+                + body
+                + "</body>\r\n"
+                + "</html>\r\n"
+                + "";
+
+        // write File
+        String htmlFileName = "dist\\" + title + ".html";
+
+        Path path = Paths.get(htmlFileName);
+
+        byte[] strToBytes = html.getBytes();
+
+        Files.write(path, strToBytes);
+
+    }
+
+    public static String readFile(File file){
+        StringBuilder sb = new StringBuilder();
+
+        try (BufferedReader br = new BufferedReader(new FileReader(file.getAbsolutePath()))) {
+            String line;
+
+            while ((line = br.readLine()) != null) {
+                if (line.equals("")) {
+                    sb.append("<br/>");
+                } else {
+                    sb.append(line).append(" ");
+                }
+            }
+
+            br.close();
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return sb.toString();
+    }
+
+    public static String getBodyFromText(String[] lines){
+        StringBuilder sb = new StringBuilder();
+
+        for(int i = 0; i < lines.length; i++){
+            if(lines[i].substring(0,2).equals("# ")){
+                sb.append("<h1>").append(lines[i].replace("# ","")).append("</h1>").append("<br/>");
+            }
+            else if(lines[i].length()==0){
+                sb.append("<br/>");
+            }
+            else{
+                sb.append("<p>").append(lines[i]).append("</p>").append("<br/>");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/com/company/Main.java
+++ b/src/com/company/Main.java
@@ -38,7 +38,20 @@ public class Main {
                 //create html
                 createHtml(file);
 
-            }else {
+            }
+            else if(inputFile.endsWith(".md")){
+                try{
+                    //if input file is only one file
+                    File file = new File(inputFile);
+                    //create html
+                    MDUtils.createHTMLFromMd(file);
+                }
+                catch(Exception ex){
+                    ex.printStackTrace();
+                }
+
+            }
+            else {
                 //if user added multiple files(directory)
                 try {
                     List<File> allFiles = Files.walk(Paths.get(inputFile))


### PR DESCRIPTION
Hi @irenejoeunpark ,

I've just added the following features for issue #9 :
- Modify file handler so that it accepts md (1): I added a few lines of code in your main() and checks if the input file ends with ".md"

-  It parses # to <h1></h1> and generates a new HTML file in ./dist folder: I created a new MDUtils class which helps to process and generate MD file to HTML. The reason why I created this new file is that I don't want your Main class to have mixed responsibilities (processing both .txt and .md files) which violates SOLID principles. I think this design makes codes easier to read and maintain. Besides, I suggest you break your codes into smaller pieces so that they can be reused. For example, createHTML() can be a separate function so that it can be re-used for both .txt and .md. 

- I've just updated features in your README.md

Please check it out.

Thanks
