### PR TITLE
Feature implementation: Double asterisks as <strong>

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ argument option "-v" or "--version" will display the current version of the appl
 
 argument option "-h" or "--help" will display the list of command options
 
-argument option "-i" or "--i" will allow user input the single file or files by passing the directory. It supports both .txt and .md (feature: Heading)
+argument option "-i" or "--i" will allow user input the single file or files by passing the directory. It supports both .txt and .md (feature: Heading, Bold)
 
 
 ----

--- a/src/com/company/DoubleAsteriskMarkdownParser.java
+++ b/src/com/company/DoubleAsteriskMarkdownParser.java
@@ -1,6 +1,6 @@
 package com.company;
 
-public class MarkdownParser {
+public class DoubleAsteriskMarkdownParser {
     private StringBuilder htmlBuffer = new StringBuilder();
     private boolean isFirstPairOfAsterisksFound = false;
     private boolean isFirstAsteriskFound = false;
@@ -70,13 +70,27 @@ public class MarkdownParser {
         return indexForOpeningDelimiter >= 0 && indexOfLastAppearingWhitespace - indexForOpeningDelimiter == 2;
     }
 
-    public static String parseMarkdownLine(String rawText) {
-        MarkdownParser parser = new MarkdownParser();
+    private void clear() {
+        htmlBuffer.setLength(0);
+        isFirstPairOfAsterisksFound = false;
+        isFirstAsteriskFound = false;
+        indexForOpeningDelimiter = -1;
+        indexOfLastAppearingWhitespace = -1;
+    }
 
-        for (int i = 0; i < rawText.length(); ++i) {
-            parser.acceptCharacter(rawText.charAt(i));
+    public static String parseMarkdownLine(String[] rawTextLines) {
+        StringBuilder paragraphs = new StringBuilder();
+        DoubleAsteriskMarkdownParser parser = new DoubleAsteriskMarkdownParser();
+
+        for (String line : rawTextLines) {
+            for (int i = 0; i < line.length(); ++i) {
+                parser.acceptCharacter(line.charAt(i));
+            }
+
+            paragraphs.append(parser.returnParsedLine());
+            parser.clear();
         }
 
-        return parser.returnParsedLine();
+        return paragraphs.toString();
     }
 }

--- a/src/com/company/MDUtils.java
+++ b/src/com/company/MDUtils.java
@@ -12,7 +12,7 @@ public class MDUtils {
         String title = convertedText.split("<br/>")[0].replace("# ","");
 
         String body = MDUtils.getBodyFromText(convertedText.split("<br/>"));
-
+        body = DoubleAsteriskMarkdownParser.parseMarkdownLine(body.split("<br/>"));
 
         // Complete HTML file
         String html = "<!doctype html>\r\n"
@@ -68,11 +68,10 @@ public class MDUtils {
         StringBuilder sb = new StringBuilder();
 
         for(int i = 0; i < lines.length; i++){
-            if(lines[i].substring(0,2).equals("# ")){
-                sb.append("<h1>").append(lines[i].replace("# ","")).append("</h1>").append("<br/>");
-            }
-            else if(lines[i].length()==0){
+            if(lines[i].length()==0){
                 sb.append("<br/>");
+            } else if(lines[i].substring(0,2).equals("# ")){
+                sb.append("<h1>").append(lines[i].replace("# ","")).append("</h1>").append("<br/>");
             }
             else{
                 sb.append("<p>").append(lines[i]).append("</p>").append("<br/>");

--- a/src/com/company/MarkdownParser.java
+++ b/src/com/company/MarkdownParser.java
@@ -1,0 +1,82 @@
+package com.company;
+
+public class MarkdownParser {
+    private StringBuilder htmlBuffer = new StringBuilder();
+    private boolean isFirstPairOfAsterisksFound = false;
+    private boolean isFirstAsteriskFound = false;
+    int indexForOpeningDelimiter = -1;
+    int indexOfLastAppearingWhitespace = -1;
+
+    public void acceptCharacter(char character) {
+        if (character == '*') {
+            if (!haveFoundFirstAsterisk()) {
+                isFirstAsteriskFound = true;
+                push(character);
+            } else if (!haveFoundFirstAsteriskPair()) {
+                isFirstAsteriskFound = false;
+                isFirstPairOfAsterisksFound = true;
+                indexForOpeningDelimiter = getCurrentCharacterIndex() - 1;
+                push(character);
+            } else if (!isSecondPairPrecededBySpace()) {
+                replaceAtBufferWith(indexForOpeningDelimiter, 2, "<strong>");
+                replaceAtBufferWith(getCurrentCharacterIndex() - 1, 1, "</strong>");
+                isFirstAsteriskFound = false;
+                isFirstPairOfAsterisksFound = false;
+            }
+        } else {
+            if (character == ' ') {
+                indexOfLastAppearingWhitespace = getCurrentCharacterIndex();
+
+                if (isFirstAsteriskPairFollowedBySpace()) {
+                    isFirstPairOfAsterisksFound = false;
+                    indexForOpeningDelimiter = -1;
+                }
+            }
+            isFirstAsteriskFound = false;
+            push(character);
+        }
+    }
+
+    private void replaceAtBufferWith(int start, int length, String s) {
+        htmlBuffer.delete(start, start + length);
+        htmlBuffer.insert(start, s);
+    }
+
+    private boolean isSecondPairPrecededBySpace() {
+        return getCurrentCharacterIndex() - indexOfLastAppearingWhitespace == 2;
+    }
+
+    private boolean haveFoundFirstAsteriskPair() {
+        return isFirstPairOfAsterisksFound;
+    }
+
+    public String returnParsedLine() {
+        return htmlBuffer.toString();
+    }
+
+    private boolean haveFoundFirstAsterisk() {
+        return isFirstAsteriskFound;
+    }
+
+    private int getCurrentCharacterIndex() {
+        return htmlBuffer.length();
+    }
+
+    private void push(char character) {
+        htmlBuffer.append(character);
+    }
+
+    private boolean isFirstAsteriskPairFollowedBySpace() {
+        return indexForOpeningDelimiter >= 0 && indexOfLastAppearingWhitespace - indexForOpeningDelimiter == 2;
+    }
+
+    public static String parseMarkdownLine(String rawText) {
+        MarkdownParser parser = new MarkdownParser();
+
+        for (int i = 0; i < rawText.length(); ++i) {
+            parser.acceptCharacter(rawText.charAt(i));
+        }
+
+        return parser.returnParsedLine();
+    }
+}


### PR DESCRIPTION
I added some logic to parse the double asterisks as <strong>. The parsing happens after we have parsed the 
`#` lines.

I also fixed a bug that would happen if you had some empty lines in the text.